### PR TITLE
feat(prowlerobserver): add first approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+output/
 .Python
 build/
 develop-eggs/

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,80 @@
+import boto3
+import subprocess
+import time
+from datetime import datetime, timedelta
+
+from prowler.lib.check.check import list_services
+
+
+def get_enabled_regions():
+    ec2_client = boto3.client('ec2')
+
+    response = ec2_client.describe_regions(AllRegions=False)
+    
+    enabled_regions = [region['RegionName'] for region in response['Regions']]
+    
+    return enabled_regions
+
+def get_cloudtrail_services(last_minutes, regions):
+    end_time = datetime.now()
+    start_time = end_time - timedelta(minutes=last_minutes)
+    services = set()
+
+    for region in regions:
+        client = boto3.client('cloudtrail', region_name=region)
+        paginator = client.get_paginator('lookup_events')
+        response_iterator = paginator.paginate(
+            StartTime=start_time,
+            EndTime=end_time,
+            PaginationConfig={
+                'PageSize': 50 
+            }
+        )
+        for page in response_iterator:
+            for event in page['Events']:
+                event_source = event['EventSource']
+                service_name = event_source.split('.')[0]
+                services.add(service_name)
+    
+    return list(services)
+
+def run_prowler(services, regions):
+    string_services = ""
+    for service in services:
+        if service in list_services("aws"):
+            string_services += f"{service} "
+
+    string_regions = ""
+    for region in regions:
+        string_regions += f"{region} "
+
+    if string_services == "":
+        print("No services found in cloudtrail for the last specified minutes that are supported by prowler")
+    else:
+        print(F"Executing prowler for the services: {string_services} in the regions: {string_regions}")
+        
+        prowler_command = f"prowler aws --service {string_services} --log-level ERROR -f {string_regions}"
+        try:
+            subprocess.run(prowler_command, shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            if e.stderr:
+                error_message = e.stderr.decode()
+                print(f"Error executing Prowler:\n{error_message}")
+
+def main():
+    minutes = 61
+    regions = get_enabled_regions()
+    while True:
+        print(f"Getting services seen in cloudtrail for the last {minutes} minutes for the regions: {regions}")
+        services = get_cloudtrail_services(minutes, regions)
+        
+        if services:
+            print(f"Found services: {services}")
+            run_prowler(services, regions)
+        else:
+            print(f"No services found in cloudtrail for the last {minutes} minutes")
+        
+        time.sleep(minutes * 60)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds new functionality to `src/main.py` to automate the process of monitoring AWS CloudTrail events and running Prowler scans on detected services. The most important changes include importing necessary libraries, defining functions to get enabled regions and CloudTrail services, and implementing a main loop to periodically run Prowler scans.

New functionality:

* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1-R80): Imported `boto3`, `subprocess`, `time`, `datetime`, and `list_services` to support AWS operations and subprocess execution.
* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1-R80): Added `get_enabled_regions` function to retrieve the list of enabled AWS regions using the EC2 client.
* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1-R80): Added `get_cloudtrail_services` function to fetch services seen in CloudTrail events within a specified time frame.
* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1-R80): Added `run_prowler` function to execute Prowler scans on detected services and regions.
* [`src/main.py`](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R1-R80): Implemented a `main` function to periodically check for CloudTrail events and run Prowler scans, with a default interval of 61 minutes.
